### PR TITLE
Add specific language notation to Markdown code block on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A danger-swift plug-in to manage/post danger checking results with markdown styl
 
 - Add dependency package to your `Package.swift` file which you import danger-swift
 
-    ```
+    ```swift
     // swift-tools-version:5.5
     ...
     let package = Package(
@@ -25,7 +25,7 @@ A danger-swift plug-in to manage/post danger checking results with markdown styl
 
 - Add the correct import to your `Dangerfile.swift` file
 
-    ```
+    ```swift
     import DangerSwiftShoki
     ```
 
@@ -33,7 +33,7 @@ A danger-swift plug-in to manage/post danger checking results with markdown styl
 
 - Just add the dependency import to your `Dangerfile.swift` file like this:
 
-    ```
+    ```swift
     import DangerSwiftShoki // package: https://github.com/yumemi-inc/danger-swift-shoki.git
     ```
 
@@ -41,13 +41,13 @@ A danger-swift plug-in to manage/post danger checking results with markdown styl
 
 - First of all create a result data structure with `CheckResult` initializer
 
-    ```
+    ```swift
     var checkResult = CheckResult(title: "My Check")
     ```
 
 - Then you can perform any check with `check` method, by returning your check result in the trailing `execution` closure
 
-    ```
+    ```swift
     checkResult.check("Test Result Check") {
         if testPassed {
             return .good
@@ -67,13 +67,13 @@ A danger-swift plug-in to manage/post danger checking results with markdown styl
 
 - You can also ask reviewers not to forget to do some manual checks with `askReviewer` method if needed
 
-    ```
+    ```swift
     checkResult.askReviewer(to: "Check whether commit messages are correctly formatted or not")
     ```
 
 - At last post the whole check result with `shoki.report` method which is available for `DangerDSL` instances
 
-    ```
+    ```swift
     danger.shoki.report(checkResult) // Assume you have initialized `danger` by code like `let danger = Danger()`
     ```
 


### PR DESCRIPTION
## Overview

For syntax highlighting, how about using of ```` ```swift ```` rather than ```` ``` ```` ?

## Comparison

| Before | After |
|--|--|
|<img width="400" alt="スクリーンショット 2021-12-01 11 51 06" src="https://user-images.githubusercontent.com/31601805/144163196-69f33e3c-200d-45f5-b3b8-7e179fe1b4c6.png">|<img width="400" alt="スクリーンショット 2021-12-01 11 51 20" src="https://user-images.githubusercontent.com/31601805/144163199-f09d8588-8a89-4619-9cf5-17f841d8a8b7.png">|


