### PR TITLE
Feature/responsibility refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,27 +39,29 @@ A danger-swift plug-in to manage/post danger checking results with markdown styl
 
 ## Usage
 
-- First of all create a result data structure with `CheckResult` initializer
+Basically just use `.shoki` property from a `DangerDSL` instance to access all features provided by DangerSwiftShoki
+
+Examples below assume you have initialized a `danger` using `Danger()` in your `Dangerfile.swift`
+
+- First of all create a report data structure with `makeInitialReport` method
 
     ```swift
-    var checkResult = CheckResult(title: "My Check")
+    var report = danger.shoki.makeInitialReport(title: "My Report")
     ```
 
-- Then you can perform any check with `check` method, by returning your check result in the trailing `execution` closure
+- Then you can perform any checks with `check` method, by returning your check result in the trailing `execution` closure
 
     ```swift
-    checkResult.check("Test Result Check") {
+    danger.shoki.check("Test Result Check", into: &report) {
         if testPassed {
             return .good
             
         } else {
             if isAcceptable {
-                warn("Encouraged to make a change but OK at this time")
-                return .acceptable
+                return .acceptable(warningMessage: "Encouraged to make a change but OK at this time")
                 
             } else {
-                fail("Must fix")
-                return .rejected
+                return .rejected(failureMessage: "Must fix")
             }
         }
     }
@@ -68,20 +70,20 @@ A danger-swift plug-in to manage/post danger checking results with markdown styl
 - You can also ask reviewers not to forget to do some manual checks with `askReviewer` method if needed
 
     ```swift
-    checkResult.askReviewer(to: "Check whether commit messages are correctly formatted or not")
+    danger.shoki.askReviewer(to: "Check whether commit messages are correctly formatted or not", into: $report)
     ```
 
-- At last post the whole check result with `shoki.report` method which is available for `DangerDSL` instances
+- At last post the whole check result with `report` method
 
     ```swift
-    danger.shoki.report(checkResult) // Assume you have initialized `danger` by code like `let danger = Danger()`
+    danger.shoki.report(report)
     ```
 
 ## Preview
 
 Code above will make danger producing markdown messages like below
 
-> ## My Check
+> ## My Report
 >
 > Checking Item | Result
 > | ---| --- |

--- a/Sources/DangerSwiftShoki/DangerDSL+.swift
+++ b/Sources/DangerSwiftShoki/DangerDSL+.swift
@@ -10,8 +10,12 @@ import Danger
 extension DangerDSL {
     
     public var shoki: Shoki {
-        return .init(markdownExecutor: { markdown($0) },
-                     messageExecutor: { message($0) })
+        return .init(
+            markdownExecutor: { markdown($0) },
+            messageExecutor: { message($0) },
+            warningExecutor: { warn($0) },
+            failureExecutor: { fail($0) }
+        )
     }
     
 }

--- a/Sources/DangerSwiftShoki/MarkdownConfiguration.swift
+++ b/Sources/DangerSwiftShoki/MarkdownConfiguration.swift
@@ -1,0 +1,113 @@
+//
+//  MarkdownConfiguration.swift
+//  
+//
+//  Created by 史 翔新 on 2021/12/02.
+//
+
+public struct MarkdownConfiguration {
+    
+    var titleMarkdownFormatter: (String) -> String
+    var messageMarkdownFormatter: ([CheckResult.CheckItem]) -> String
+    var warningMarkdownFormatter: (CheckResult.WarningMessage) -> String
+    var failureMarkdownFormatter: (CheckResult.FailureMessage) -> String
+    var todosMarkdownFormatter: ([String]) -> String
+    var congratulationsMessage: String
+    
+    public static func defaultTitleMarkdown(title: String) -> String {
+        
+        "## " + title
+        
+    }
+    
+    public static func defaultMessageMarkdown(checkItems: [CheckResult.CheckItem]) -> String {
+        
+        guard !checkItems.isEmpty else {
+            return ""
+        }
+        
+        let chartHeader = """
+            Checking Item | Result
+            | ---| --- |
+            
+            """
+        let chartContent = checkItems.map {
+            "\($0.title) | \($0.result.markdownSymbol)"
+        } .joined(separator: "\n")
+        
+        return chartHeader + chartContent
+        
+    }
+    
+    public static func defaultWarningMarkdown(warning: CheckResult.WarningMessage) -> String {
+        
+        let messageSuffix = warning.message.map { ": \($0)" } ?? " has a warning."
+        return warning.title + messageSuffix
+        
+    }
+    
+    public static func defaultFailureMarkdown(failure: CheckResult.FailureMessage) -> String {
+        
+        let messageSuffix = failure.message.map { ": \($0)" } ?? " failed."
+        return failure.title + messageSuffix
+        
+    }
+    
+    public static func defaultTodosMarkdown(todos: [String]) -> String {
+        
+        guard !todos.isEmpty else {
+            return ""
+        }
+        
+        let todoContent = todos.map {
+            "- [ ] \($0)"
+        }
+        
+        return todoContent.joined(separator: "\n")
+        
+    }
+    
+    public static var defaultCongratulationsMessage: String {
+        
+        "Good Job :white_flower:"
+        
+    }
+    
+    public init(
+        titleMarkdownFormatter: @escaping (String) -> String = defaultTitleMarkdown(title:),
+        messageMarkdownFormatter: @escaping ([CheckResult.CheckItem]) -> String = defaultMessageMarkdown(checkItems:),
+        warningMarkdownFormatter: @escaping (CheckResult.WarningMessage) -> String = defaultWarningMarkdown(warning:),
+        failureMarkdownFormatter: @escaping (CheckResult.FailureMessage) -> String = defaultFailureMarkdown(failure:),
+        todosMarkdownFormatter: @escaping ([String]) -> String = defaultTodosMarkdown(todos:),
+        congratulationsMessage: String = defaultCongratulationsMessage
+    ) {
+        self.titleMarkdownFormatter = titleMarkdownFormatter
+        self.messageMarkdownFormatter = messageMarkdownFormatter
+        self.warningMarkdownFormatter = warningMarkdownFormatter
+        self.failureMarkdownFormatter = failureMarkdownFormatter
+        self.todosMarkdownFormatter = todosMarkdownFormatter
+        self.congratulationsMessage = congratulationsMessage
+    }
+    
+    public static var `default`: MarkdownConfiguration {
+        .init()
+    }
+    
+}
+
+private extension CheckResult.Result {
+    
+    var markdownSymbol: String {
+        switch self {
+        case .good:
+            return ":tada:"
+            
+        case .acceptable:
+            return ":thinking:"
+            
+        case .rejected:
+            return ":no_good:"
+        }
+    }
+    
+}

--- a/Sources/DangerSwiftShoki/MarkdownConfiguration.swift
+++ b/Sources/DangerSwiftShoki/MarkdownConfiguration.swift
@@ -8,9 +8,9 @@
 public struct MarkdownConfiguration {
     
     var titleMarkdownFormatter: (String) -> String
-    var messageMarkdownFormatter: ([CheckResult.CheckItem]) -> String
-    var warningMarkdownFormatter: (CheckResult.WarningMessage) -> String
-    var failureMarkdownFormatter: (CheckResult.FailureMessage) -> String
+    var messageMarkdownFormatter: ([Report.CheckItem]) -> String
+    var warningMarkdownFormatter: (Report.WarningMessage) -> String
+    var failureMarkdownFormatter: (Report.FailureMessage) -> String
     var todosMarkdownFormatter: ([String]) -> String
     var congratulationsMessage: String
     
@@ -20,7 +20,7 @@ public struct MarkdownConfiguration {
         
     }
     
-    public static func defaultMessageMarkdown(checkItems: [CheckResult.CheckItem]) -> String {
+    public static func defaultMessageMarkdown(checkItems: [Report.CheckItem]) -> String {
         
         guard !checkItems.isEmpty else {
             return ""
@@ -39,14 +39,14 @@ public struct MarkdownConfiguration {
         
     }
     
-    public static func defaultWarningMarkdown(warning: CheckResult.WarningMessage) -> String {
+    public static func defaultWarningMarkdown(warning: Report.WarningMessage) -> String {
         
         let messageSuffix = warning.message.map { ": \($0)" } ?? " has a warning."
         return warning.title + messageSuffix
         
     }
     
-    public static func defaultFailureMarkdown(failure: CheckResult.FailureMessage) -> String {
+    public static func defaultFailureMarkdown(failure: Report.FailureMessage) -> String {
         
         let messageSuffix = failure.message.map { ": \($0)" } ?? " failed."
         return failure.title + messageSuffix
@@ -75,9 +75,9 @@ public struct MarkdownConfiguration {
     
     public init(
         titleMarkdownFormatter: @escaping (String) -> String = defaultTitleMarkdown(title:),
-        messageMarkdownFormatter: @escaping ([CheckResult.CheckItem]) -> String = defaultMessageMarkdown(checkItems:),
-        warningMarkdownFormatter: @escaping (CheckResult.WarningMessage) -> String = defaultWarningMarkdown(warning:),
-        failureMarkdownFormatter: @escaping (CheckResult.FailureMessage) -> String = defaultFailureMarkdown(failure:),
+        messageMarkdownFormatter: @escaping ([Report.CheckItem]) -> String = defaultMessageMarkdown(checkItems:),
+        warningMarkdownFormatter: @escaping (Report.WarningMessage) -> String = defaultWarningMarkdown(warning:),
+        failureMarkdownFormatter: @escaping (Report.FailureMessage) -> String = defaultFailureMarkdown(failure:),
         todosMarkdownFormatter: @escaping ([String]) -> String = defaultTodosMarkdown(todos:),
         congratulationsMessage: String = defaultCongratulationsMessage
     ) {
@@ -95,7 +95,7 @@ public struct MarkdownConfiguration {
     
 }
 
-private extension CheckResult.Result {
+private extension Report.Result {
     
     var markdownSymbol: String {
         switch self {

--- a/Sources/DangerSwiftShoki/MarkdownConfiguration.swift
+++ b/Sources/DangerSwiftShoki/MarkdownConfiguration.swift
@@ -95,7 +95,7 @@ public struct MarkdownConfiguration {
     
 }
 
-private extension Report.Result {
+private extension Report.CheckItem.Result {
     
     var markdownSymbol: String {
         switch self {

--- a/Sources/DangerSwiftShoki/Report.swift
+++ b/Sources/DangerSwiftShoki/Report.swift
@@ -5,15 +5,21 @@
 //  Created by 史 翔新 on 2020/07/11.
 //
 
-public struct Report {
+public struct Report: Equatable {
     
-    public enum Result: Equatable {
-        case good
-        case acceptable(warningMessage: String?)
-        case rejected(failureMessage: String?)
+    public struct CheckItem: Equatable {
+        
+        public enum Result: Equatable {
+            case good
+            case acceptable(warningMessage: String?)
+            case rejected(failureMessage: String?)
+        }
+        
+        let title: String
+        let result: Result
+        
     }
     
-    public typealias CheckItem = (title: String, result: Result)
     public typealias WarningMessage = (title: String, message: String?)
     public typealias FailureMessage = (title: String, message: String?)
     
@@ -25,10 +31,10 @@ public struct Report {
     
     public var warnings: AnyCollection<WarningMessage> {
         
-        checkItems.lazy.compactMap { (title, result) in
-            switch result {
+        checkItems.lazy.compactMap { item in
+            switch item.result {
             case .acceptable(warningMessage: let warning):
-                return (title, warning)
+                return (item.title, warning)
                 
             case .good, .rejected:
                 return nil
@@ -40,10 +46,10 @@ public struct Report {
     
     public var failures: AnyCollection<FailureMessage> {
         
-        checkItems.compactMap { (title, result) in
-            switch result {
+        checkItems.compactMap { item in
+            switch item.result {
             case .rejected(failureMessage: let failure):
-                return (title, failure)
+                return (item.title, failure)
                 
             case .good, .acceptable:
                 return nil
@@ -115,7 +121,7 @@ public struct Report {
 @available(*, deprecated, renamed: "Report")
 public typealias CheckResult = Report
 
-private extension Report.Result {
+private extension Report.CheckItem.Result {
     
     var markdownSymbol: String {
         switch self {

--- a/Sources/DangerSwiftShoki/Report.swift
+++ b/Sources/DangerSwiftShoki/Report.swift
@@ -1,11 +1,11 @@
 //
-//  CheckResult.swift
+//  Report.swift
 //  
 //
 //  Created by 史 翔新 on 2020/07/11.
 //
 
-public struct CheckResult {
+public struct Report {
     
     public enum Result: Equatable {
         case good
@@ -67,14 +67,14 @@ public struct CheckResult {
         self.title = title
     }
     
-    @available(*, deprecated, message: "It's `Shoki`'s responsibility to format a message, not `CheckResult`'s, so stop using this property to get the formatted title, which you shouldn't have to care at first place.")
+    @available(*, deprecated, message: "It's `Shoki`'s responsibility to format a message, not `CheckResult`'s, so stop using this property to get the formatted title, which you shouldn't have to care about at first place.")
     public var markdownTitle: String {
         
         "## " + title
         
     }
     
-    @available(*, deprecated, message: "It's `Shoki`'s responsibility to format a message, not `CheckResult`'s, so stop using this property to get the formatted message, which you shouldn't have to care at first place.")
+    @available(*, deprecated, message: "It's `Shoki`'s responsibility to format a message, not `CheckResult`'s, so stop using this property to get the formatted message, which you shouldn't have to care about at first place.")
     public var markdownMessage: String {
         
         guard !checkItems.isEmpty else {
@@ -94,7 +94,7 @@ public struct CheckResult {
         
     }
     
-    @available(*, deprecated, message: "It's `Shoki`'s responsibility to format a message, not `CheckResult`'s, so stop using this property to get the formatted todos, which you shouldn't have to care at first place.")
+    @available(*, deprecated, message: "It's `Shoki`'s responsibility to format a message, not `CheckResult`'s, so stop using this property to get the formatted todos, which you shouldn't have to care about at first place.")
     public var markdownTodos: String {
         
         guard !todos.isEmpty else {
@@ -111,7 +111,11 @@ public struct CheckResult {
     
 }
 
-private extension CheckResult.Result {
+
+@available(*, deprecated, renamed: "Report")
+public typealias CheckResult = Report
+
+private extension Report.Result {
     
     var markdownSymbol: String {
         switch self {

--- a/Sources/DangerSwiftShoki/Report.swift
+++ b/Sources/DangerSwiftShoki/Report.swift
@@ -46,7 +46,7 @@ public struct Report: Equatable {
     
     public var failures: AnyCollection<FailureMessage> {
         
-        checkItems.compactMap { item in
+        checkItems.lazy.compactMap { item in
             switch item.result {
             case .rejected(failureMessage: let failure):
                 return (item.title, failure)

--- a/Sources/DangerSwiftShoki/Shoki.swift
+++ b/Sources/DangerSwiftShoki/Shoki.swift
@@ -50,53 +50,53 @@ extension Shoki {
 
 extension Shoki {
     
-    public func makeInitialCheckResult(title: String) -> CheckResult {
+    public func makeInitialReport(title: String) -> Report {
         
         .init(title: title)
         
     }
     
-    public func check(_ title: String, into result: inout CheckResult, execution: () -> CheckResult.Result) {
+    public func check(_ title: String, into report: inout Report, execution: () -> Report.Result) {
         
         let executionResult = execution()
-        result.checkItems.append((title, executionResult))
+        report.checkItems.append((title, executionResult))
         
     }
     
-    public func askReviewer(to taskToDo: String, into result: inout CheckResult) {
+    public func askReviewer(to taskToDo: String, into report: inout Report) {
         
-        result.todos.append(taskToDo)
+        report.todos.append(taskToDo)
         
     }
     
-    public func report(_ result: CheckResult, using configuration: MarkdownConfiguration = .default) {
+    public func report(_ report: Report, using configuration: MarkdownConfiguration = .default) {
         
-        let markdownTitle = configuration.titleMarkdownFormatter(result.title)
+        let markdownTitle = configuration.titleMarkdownFormatter(report.title)
         if !markdownTitle.isEmpty {
             markdown(markdownTitle)
         }
         
-        let markdownMessage = configuration.messageMarkdownFormatter(result.checkItems)
+        let markdownMessage = configuration.messageMarkdownFormatter(report.checkItems)
         if !markdownMessage.isEmpty {
             markdown(markdownMessage)
         }
         
-        for warning in result.warnings {
+        for warning in report.warnings {
             let markdownWarning = configuration.warningMarkdownFormatter(warning)
             warn(markdownWarning)
         }
         
-        for failure in result.failures {
+        for failure in report.failures {
             let markdownFailure = configuration.failureMarkdownFormatter(failure)
             fail(markdownFailure)
         }
         
-        let markdownTodos = configuration.todosMarkdownFormatter(result.todos)
+        let markdownTodos = configuration.todosMarkdownFormatter(report.todos)
         if !markdownTodos.isEmpty {
             markdown(markdownTodos)
         }
 
-        if result.warnings.isEmpty && result.failures.isEmpty {
+        if report.warnings.isEmpty && report.failures.isEmpty {
             message(configuration.congratulationsMessage)
         }
         

--- a/Sources/DangerSwiftShoki/Shoki.swift
+++ b/Sources/DangerSwiftShoki/Shoki.swift
@@ -56,10 +56,10 @@ extension Shoki {
         
     }
     
-    public func check(_ title: String, into report: inout Report, execution: () -> Report.Result) {
+    public func check(_ title: String, into report: inout Report, execution: () -> Report.CheckItem.Result) {
         
         let executionResult = execution()
-        report.checkItems.append((title, executionResult))
+        report.checkItems.append(.init(title: title, result: executionResult))
         
     }
     

--- a/Sources/DangerSwiftShoki/Shoki.swift
+++ b/Sources/DangerSwiftShoki/Shoki.swift
@@ -50,6 +50,25 @@ extension Shoki {
 
 extension Shoki {
     
+    public func makeInitialCheckResult(title: String) -> CheckResult {
+        
+        .init(title: title)
+        
+    }
+    
+    public func check(_ title: String, into result: inout CheckResult, execution: () -> CheckResult.Result) {
+        
+        let executionResult = execution()
+        result.checkItems.append((title, executionResult))
+        
+    }
+    
+    public func askReviewer(to taskToDo: String, into result: inout CheckResult) {
+        
+        result.todos.append(taskToDo)
+        
+    }
+    
     public func report(_ result: CheckResult, using configuration: MarkdownConfiguration = .default) {
         
         let markdownTitle = configuration.titleMarkdownFormatter(result.title)

--- a/Tests/DangerSwiftShokiTests/CheckResultTests.swift
+++ b/Tests/DangerSwiftShokiTests/CheckResultTests.swift
@@ -9,100 +9,87 @@ final class CheckResultTests: XCTestCase {
         
         XCTContext.runActivity(named: "Initialize CheckResult") { _ in
             XCTAssertEqual(checkResult.title, "Test Check")
-            XCTAssertEqual(checkResult.warningsCount, 0)
-            XCTAssertEqual(checkResult.errorsCount, 0)
-            XCTAssertEqual(checkResult.markdownTitle, "## Test Check")
-            XCTAssertEqual(checkResult.markdownMessage, """
-                                                        """)
-            XCTAssertEqual(checkResult.markdownTodos, """
-                                                      """)
+            XCTAssertEqual(checkResult.checkItems, [])
+            XCTAssertEqual(checkResult.todos, [])
+            XCTAssertEqual(checkResult.warnings, [])
+            XCTAssertEqual(checkResult.failures, [])
         }
         
         XCTContext.runActivity(named: "Add Check Item with Good Result") { _ in
-            checkResult.check("Good Check", execution: { .good })
+            checkResult.checkItems.append(("Good Check", .good))
             XCTAssertEqual(checkResult.title, "Test Check")
-            XCTAssertEqual(checkResult.warningsCount, 0)
-            XCTAssertEqual(checkResult.errorsCount, 0)
-            XCTAssertEqual(checkResult.markdownTitle, "## Test Check")
-            XCTAssertEqual(checkResult.markdownMessage, """
-                                                        Checking Item | Result
-                                                        | ---| --- |
-                                                        Good Check | :tada:
-                                                        """)
-            XCTAssertEqual(checkResult.markdownTodos, """
-                                                      """)
+            XCTAssertEqual(checkResult.checkItems, [("Good Check", .good)])
+            XCTAssertEqual(checkResult.todos, [])
+            XCTAssertEqual(checkResult.warnings, [])
+            XCTAssertEqual(checkResult.failures, [])
         }
         
         XCTContext.runActivity(named: "Add Check Item with Acceptable Result") { _ in
-            checkResult.check("Acceptable Check", execution: { .acceptable })
+            checkResult.checkItems.append(("Acceptable Check", .acceptable(warningMessage: "Warning")))
             XCTAssertEqual(checkResult.title, "Test Check")
-            XCTAssertEqual(checkResult.warningsCount, 1)
-            XCTAssertEqual(checkResult.errorsCount, 0)
-            XCTAssertEqual(checkResult.markdownTitle, "## Test Check")
-            XCTAssertEqual(checkResult.markdownMessage, """
-                                                        Checking Item | Result
-                                                        | ---| --- |
-                                                        Good Check | :tada:
-                                                        Acceptable Check | :thinking:
-                                                        """)
-            XCTAssertEqual(checkResult.markdownTodos, """
-                                                      """)
+            XCTAssertEqual(checkResult.checkItems, [("Good Check", .good),
+                                                    ("Acceptable Check", .acceptable(warningMessage: "Warning"))])
+            XCTAssertEqual(checkResult.todos, [])
+            XCTAssertEqual(checkResult.warnings, [("Acceptable Check", "Warning")])
+            XCTAssertEqual(checkResult.failures, [])
         }
         
         XCTContext.runActivity(named: "Add Check Item with Rejected Result") { _ in
-            checkResult.check("Rejected Check", execution: { .rejected })
+            checkResult.checkItems.append(("Rejected Check", .rejected(failureMessage: "Failure")))
             XCTAssertEqual(checkResult.title, "Test Check")
-            XCTAssertEqual(checkResult.warningsCount, 1)
-            XCTAssertEqual(checkResult.errorsCount, 1)
-            XCTAssertEqual(checkResult.markdownTitle, "## Test Check")
-            XCTAssertEqual(checkResult.markdownMessage, """
-                                                        Checking Item | Result
-                                                        | ---| --- |
-                                                        Good Check | :tada:
-                                                        Acceptable Check | :thinking:
-                                                        Rejected Check | :no_good:
-                                                        """)
-            XCTAssertEqual(checkResult.markdownTodos, """
-                                                      """)
+            XCTAssertEqual(checkResult.checkItems, [("Good Check", .good),
+                                                    ("Acceptable Check", .acceptable(warningMessage: "Warning")),
+                                                    ("Rejected Check", .rejected(failureMessage: "Failure"))])
+            XCTAssertEqual(checkResult.todos, [])
+            XCTAssertEqual(checkResult.warnings, [("Acceptable Check", "Warning")])
+            XCTAssertEqual(checkResult.failures, [("Rejected Check", "Failure")])
         }
         
         XCTContext.runActivity(named: "Add A Todo Item") { _ in
-            checkResult.askReviewer(to: "Do Something")
+            checkResult.todos.append("Do Something")
             XCTAssertEqual(checkResult.title, "Test Check")
-            XCTAssertEqual(checkResult.warningsCount, 1)
-            XCTAssertEqual(checkResult.errorsCount, 1)
-            XCTAssertEqual(checkResult.markdownTitle, "## Test Check")
-            XCTAssertEqual(checkResult.markdownMessage, """
-                                                        Checking Item | Result
-                                                        | ---| --- |
-                                                        Good Check | :tada:
-                                                        Acceptable Check | :thinking:
-                                                        Rejected Check | :no_good:
-                                                        """)
-            XCTAssertEqual(checkResult.markdownTodos, """
-                                                      - [ ] Do Something
-                                                      """)
+            XCTAssertEqual(checkResult.checkItems, [("Good Check", .good),
+                                                    ("Acceptable Check", .acceptable(warningMessage: "Warning")),
+                                                    ("Rejected Check", .rejected(failureMessage: "Failure"))])
+            XCTAssertEqual(checkResult.todos, ["Do Something"])
+            XCTAssertEqual(checkResult.warnings, [("Acceptable Check", "Warning")])
+            XCTAssertEqual(checkResult.failures, [("Rejected Check", "Failure")])
         }
         
         XCTContext.runActivity(named: "Add Another Todo Item") { _ in
-            checkResult.askReviewer(to: "Do Another Thing")
+            checkResult.todos.append("Do Another Thing")
             XCTAssertEqual(checkResult.title, "Test Check")
-            XCTAssertEqual(checkResult.warningsCount, 1)
-            XCTAssertEqual(checkResult.errorsCount, 1)
-            XCTAssertEqual(checkResult.markdownTitle, "## Test Check")
-            XCTAssertEqual(checkResult.markdownMessage, """
-                                                        Checking Item | Result
-                                                        | ---| --- |
-                                                        Good Check | :tada:
-                                                        Acceptable Check | :thinking:
-                                                        Rejected Check | :no_good:
-                                                        """)
-            XCTAssertEqual(checkResult.markdownTodos, """
-                                                      - [ ] Do Something
-                                                      - [ ] Do Another Thing
-                                                      """)
+            XCTAssertEqual(checkResult.checkItems, [("Good Check", .good),
+                                                    ("Acceptable Check", .acceptable(warningMessage: "Warning")),
+                                                    ("Rejected Check", .rejected(failureMessage: "Failure"))])
+            XCTAssertEqual(checkResult.todos, ["Do Something",
+                                               "Do Another Thing"])
+            XCTAssertEqual(checkResult.warnings, [("Acceptable Check", "Warning")])
+            XCTAssertEqual(checkResult.failures, [("Rejected Check", "Failure")])
         }
         
+    }
+    
+}
+
+private func XCTAssertEqual(_ itemA: [CheckResult.CheckItem], _ itemB: [CheckResult.CheckItem], line: UInt = #line) {
+    
+    XCTAssertEqual(itemA.count, itemB.count, line: line)
+    
+    for itemTuple in zip(itemA, itemB) {
+        XCTAssertEqual(itemTuple.0.title, itemTuple.1.title, line: line)
+        XCTAssertEqual(itemTuple.0.result, itemTuple.1.result, line: line)
+    }
+    
+}
+
+private func XCTAssertEqual(_ itemA: AnyCollection<CheckResult.WarningMessage>, _ itemB: [CheckResult.WarningMessage], line: UInt = #line) {
+    
+    XCTAssertEqual(itemA.count, itemB.count, line: line)
+    
+    for itemTuple in zip(itemA, itemB) {
+        XCTAssertEqual(itemTuple.0.title, itemTuple.1.title, line: line)
+        XCTAssertEqual(itemTuple.0.message, itemTuple.1.message, line: line)
     }
     
 }

--- a/Tests/DangerSwiftShokiTests/MarkdownConfigurationTests.swift
+++ b/Tests/DangerSwiftShokiTests/MarkdownConfigurationTests.swift
@@ -26,12 +26,12 @@ final class MarkdownConfigurationTests: XCTestCase {
         
         XCTContext.runActivity(named: "Check Message Markdown") { _ in
             
-            let emptyCheckItems: [CheckResult.CheckItem] = []
+            let emptyCheckItems: [Report.CheckItem] = []
             let expectedEmptyOutput = ""
             XCTAssertEqual(MC.defaultMessageMarkdown(checkItems: emptyCheckItems), expectedEmptyOutput)
             XCTAssertEqual(mc.messageMarkdownFormatter(emptyCheckItems), expectedEmptyOutput)
             
-            let singleElementCheckItems: [CheckResult.CheckItem] = [("Test 1", .good)]
+            let singleElementCheckItems: [Report.CheckItem] = [("Test 1", .good)]
             let expectedSingleElementOutput = """
                 Checking Item | Result
                 | ---| --- |
@@ -40,7 +40,7 @@ final class MarkdownConfigurationTests: XCTestCase {
             XCTAssertEqual(MC.defaultMessageMarkdown(checkItems: singleElementCheckItems), expectedSingleElementOutput)
             XCTAssertEqual(mc.messageMarkdownFormatter(singleElementCheckItems), expectedSingleElementOutput)
             
-            let multipleElementCheckItems: [CheckResult.CheckItem] = [("Test 2", .acceptable(warningMessage: nil)), ("Test 3", .rejected(failureMessage: "NG"))]
+            let multipleElementCheckItems: [Report.CheckItem] = [("Test 2", .acceptable(warningMessage: nil)), ("Test 3", .rejected(failureMessage: "NG"))]
             let expectedMultipleElementOutput = """
                 Checking Item | Result
                 | ---| --- |

--- a/Tests/DangerSwiftShokiTests/MarkdownConfigurationTests.swift
+++ b/Tests/DangerSwiftShokiTests/MarkdownConfigurationTests.swift
@@ -31,7 +31,9 @@ final class MarkdownConfigurationTests: XCTestCase {
             XCTAssertEqual(MC.defaultMessageMarkdown(checkItems: emptyCheckItems), expectedEmptyOutput)
             XCTAssertEqual(mc.messageMarkdownFormatter(emptyCheckItems), expectedEmptyOutput)
             
-            let singleElementCheckItems: [Report.CheckItem] = [("Test 1", .good)]
+            let singleElementCheckItems: [Report.CheckItem] = [
+                .init(title: "Test 1", result: .good)
+            ]
             let expectedSingleElementOutput = """
                 Checking Item | Result
                 | ---| --- |
@@ -40,7 +42,10 @@ final class MarkdownConfigurationTests: XCTestCase {
             XCTAssertEqual(MC.defaultMessageMarkdown(checkItems: singleElementCheckItems), expectedSingleElementOutput)
             XCTAssertEqual(mc.messageMarkdownFormatter(singleElementCheckItems), expectedSingleElementOutput)
             
-            let multipleElementCheckItems: [Report.CheckItem] = [("Test 2", .acceptable(warningMessage: nil)), ("Test 3", .rejected(failureMessage: "NG"))]
+            let multipleElementCheckItems: [Report.CheckItem] = [
+                .init(title: "Test 2", result: .acceptable(warningMessage: nil)),
+                .init(title: "Test 3", result: .rejected(failureMessage: "NG"))
+            ]
             let expectedMultipleElementOutput = """
                 Checking Item | Result
                 | ---| --- |

--- a/Tests/DangerSwiftShokiTests/MarkdownConfigurationTests.swift
+++ b/Tests/DangerSwiftShokiTests/MarkdownConfigurationTests.swift
@@ -1,0 +1,115 @@
+//
+//  MarkdownConfigurationTests.swift
+//  
+//
+//  Created by 史 翔新 on 2021/12/02.
+//
+
+import XCTest
+@testable import DangerSwiftShoki
+
+final class MarkdownConfigurationTests: XCTestCase {
+    
+    func test_defaultConfigurations() {
+        
+        typealias MC = MarkdownConfiguration
+        let mc = MC.default
+        
+        XCTContext.runActivity(named: "Check Title Markdown") { _ in
+            
+            let title = "Test Title"
+            let expected = "## Test Title"
+            XCTAssertEqual(MC.defaultTitleMarkdown(title: title), expected)
+            XCTAssertEqual(mc.titleMarkdownFormatter(title), expected)
+            
+        }
+        
+        XCTContext.runActivity(named: "Check Message Markdown") { _ in
+            
+            let emptyCheckItems: [CheckResult.CheckItem] = []
+            let expectedEmptyOutput = ""
+            XCTAssertEqual(MC.defaultMessageMarkdown(checkItems: emptyCheckItems), expectedEmptyOutput)
+            XCTAssertEqual(mc.messageMarkdownFormatter(emptyCheckItems), expectedEmptyOutput)
+            
+            let singleElementCheckItems: [CheckResult.CheckItem] = [("Test 1", .good)]
+            let expectedSingleElementOutput = """
+                Checking Item | Result
+                | ---| --- |
+                Test 1 | :tada:
+                """
+            XCTAssertEqual(MC.defaultMessageMarkdown(checkItems: singleElementCheckItems), expectedSingleElementOutput)
+            XCTAssertEqual(mc.messageMarkdownFormatter(singleElementCheckItems), expectedSingleElementOutput)
+            
+            let multipleElementCheckItems: [CheckResult.CheckItem] = [("Test 2", .acceptable(warningMessage: nil)), ("Test 3", .rejected(failureMessage: "NG"))]
+            let expectedMultipleElementOutput = """
+                Checking Item | Result
+                | ---| --- |
+                Test 2 | :thinking:
+                Test 3 | :no_good:
+                """
+            XCTAssertEqual(MC.defaultMessageMarkdown(checkItems: multipleElementCheckItems), expectedMultipleElementOutput)
+            XCTAssertEqual(mc.messageMarkdownFormatter(multipleElementCheckItems), expectedMultipleElementOutput)
+            
+        }
+        
+        XCTContext.runActivity(named: "Check Warning Markdown") { _ in
+            
+            let warningTitle = "Warning Title"
+            let nonNilMessage = "Needs Further Check"
+            let expectedNilMessageOutput = "Warning Title has a warning."
+            let expectedNonNilMessageOutput = "Warning Title: Needs Further Check"
+            XCTAssertEqual(MC.defaultWarningMarkdown(warning: (warningTitle, nil)), expectedNilMessageOutput)
+            XCTAssertEqual(mc.warningMarkdownFormatter((warningTitle, nil)), expectedNilMessageOutput)
+            XCTAssertEqual(MC.defaultWarningMarkdown(warning: (warningTitle, nonNilMessage)), expectedNonNilMessageOutput)
+            XCTAssertEqual(mc.warningMarkdownFormatter((warningTitle, nonNilMessage)), expectedNonNilMessageOutput)
+            
+        }
+        
+        XCTContext.runActivity(named: "Check Failure Markdown") { _ in
+            
+            let failureTitle = "Failure Title"
+            let nonNilMessage = "NO GOOD"
+            let expectedNilMessageOutput = "Failure Title failed."
+            let expectedNonNilMessageOutput = "Failure Title: NO GOOD"
+            XCTAssertEqual(MC.defaultFailureMarkdown(failure: (failureTitle, nil)), expectedNilMessageOutput)
+            XCTAssertEqual(mc.failureMarkdownFormatter((failureTitle, nil)), expectedNilMessageOutput)
+            XCTAssertEqual(MC.defaultFailureMarkdown(failure: (failureTitle, nonNilMessage)), expectedNonNilMessageOutput)
+            XCTAssertEqual(mc.failureMarkdownFormatter((failureTitle, nonNilMessage)), expectedNonNilMessageOutput)
+            
+        }
+        
+        XCTContext.runActivity(named: "Check Todo Markdown") { _ in
+            
+            let emptyTodos: [String] = []
+            let expectedEmptyOutput = ""
+            XCTAssertEqual(MC.defaultTodosMarkdown(todos: emptyTodos), expectedEmptyOutput)
+            XCTAssertEqual(mc.todosMarkdownFormatter(emptyTodos), expectedEmptyOutput)
+            
+            let singleElementTodos = ["Todo 1"]
+            let expectedSingleElementOutput = """
+                - [ ] Todo 1
+                """
+            XCTAssertEqual(MC.defaultTodosMarkdown(todos: singleElementTodos), expectedSingleElementOutput)
+            XCTAssertEqual(mc.todosMarkdownFormatter(singleElementTodos), expectedSingleElementOutput)
+            
+            let multipleElementTodos = ["Todo 1", "Todo 2"]
+            let expectedMultipleElementOutput = """
+                - [ ] Todo 1
+                - [ ] Todo 2
+                """
+            XCTAssertEqual(MC.defaultTodosMarkdown(todos: multipleElementTodos), expectedMultipleElementOutput)
+            XCTAssertEqual(mc.todosMarkdownFormatter(multipleElementTodos), expectedMultipleElementOutput)
+            
+        }
+        
+        XCTContext.runActivity(named: "Check Congratulations Message") { _ in
+            
+            let expected = "Good Job :white_flower:"
+            XCTAssertEqual(MC.defaultCongratulationsMessage, expected)
+            XCTAssertEqual(mc.congratulationsMessage, expected)
+            
+        }
+        
+    }
+    
+}

--- a/Tests/DangerSwiftShokiTests/ReportTests.swift
+++ b/Tests/DangerSwiftShokiTests/ReportTests.swift
@@ -3,93 +3,43 @@ import XCTest
 
 final class ReportTests: XCTestCase {
     
-    func test_reportUsageScenario() {
+    private func dummyReport() -> Report {
+        var report = Report(title: "")
+        report.checkItems = [
+            .init(title: "GOOD", result: .good),
+            .init(title: "WARNING 1", result: .acceptable(warningMessage: "Warning Message")),
+            .init(title: "WARNING 2", result: .acceptable(warningMessage: nil)),
+            .init(title: "FAILURE 1", result: .rejected(failureMessage: "Failure Message")),
+            .init(title: "FAILURE 2", result: .rejected(failureMessage: nil)),
+        ]
+        return report
+    }
+    
+    func test_warnings() {
         
-        var checkResult = Report(title: "Test Check")
+        let inputReport = dummyReport()
+        XCTAssertEqual(inputReport.warnings, [("WARNING 1", "Warning Message"), ("WARNING 2", nil)])
         
-        XCTContext.runActivity(named: "Initialize CheckResult") { _ in
-            XCTAssertEqual(checkResult.title, "Test Check")
-            XCTAssertEqual(checkResult.checkItems, [])
-            XCTAssertEqual(checkResult.todos, [])
-            XCTAssertEqual(checkResult.warnings, [])
-            XCTAssertEqual(checkResult.failures, [])
-        }
+    }
+    
+    func test_failures() {
         
-        XCTContext.runActivity(named: "Add Check Item with Good Result") { _ in
-            checkResult.checkItems.append(("Good Check", .good))
-            XCTAssertEqual(checkResult.title, "Test Check")
-            XCTAssertEqual(checkResult.checkItems, [("Good Check", .good)])
-            XCTAssertEqual(checkResult.todos, [])
-            XCTAssertEqual(checkResult.warnings, [])
-            XCTAssertEqual(checkResult.failures, [])
-        }
-        
-        XCTContext.runActivity(named: "Add Check Item with Acceptable Result") { _ in
-            checkResult.checkItems.append(("Acceptable Check", .acceptable(warningMessage: "Warning")))
-            XCTAssertEqual(checkResult.title, "Test Check")
-            XCTAssertEqual(checkResult.checkItems, [("Good Check", .good),
-                                                    ("Acceptable Check", .acceptable(warningMessage: "Warning"))])
-            XCTAssertEqual(checkResult.todos, [])
-            XCTAssertEqual(checkResult.warnings, [("Acceptable Check", "Warning")])
-            XCTAssertEqual(checkResult.failures, [])
-        }
-        
-        XCTContext.runActivity(named: "Add Check Item with Rejected Result") { _ in
-            checkResult.checkItems.append(("Rejected Check", .rejected(failureMessage: "Failure")))
-            XCTAssertEqual(checkResult.title, "Test Check")
-            XCTAssertEqual(checkResult.checkItems, [("Good Check", .good),
-                                                    ("Acceptable Check", .acceptable(warningMessage: "Warning")),
-                                                    ("Rejected Check", .rejected(failureMessage: "Failure"))])
-            XCTAssertEqual(checkResult.todos, [])
-            XCTAssertEqual(checkResult.warnings, [("Acceptable Check", "Warning")])
-            XCTAssertEqual(checkResult.failures, [("Rejected Check", "Failure")])
-        }
-        
-        XCTContext.runActivity(named: "Add A Todo Item") { _ in
-            checkResult.todos.append("Do Something")
-            XCTAssertEqual(checkResult.title, "Test Check")
-            XCTAssertEqual(checkResult.checkItems, [("Good Check", .good),
-                                                    ("Acceptable Check", .acceptable(warningMessage: "Warning")),
-                                                    ("Rejected Check", .rejected(failureMessage: "Failure"))])
-            XCTAssertEqual(checkResult.todos, ["Do Something"])
-            XCTAssertEqual(checkResult.warnings, [("Acceptable Check", "Warning")])
-            XCTAssertEqual(checkResult.failures, [("Rejected Check", "Failure")])
-        }
-        
-        XCTContext.runActivity(named: "Add Another Todo Item") { _ in
-            checkResult.todos.append("Do Another Thing")
-            XCTAssertEqual(checkResult.title, "Test Check")
-            XCTAssertEqual(checkResult.checkItems, [("Good Check", .good),
-                                                    ("Acceptable Check", .acceptable(warningMessage: "Warning")),
-                                                    ("Rejected Check", .rejected(failureMessage: "Failure"))])
-            XCTAssertEqual(checkResult.todos, ["Do Something",
-                                               "Do Another Thing"])
-            XCTAssertEqual(checkResult.warnings, [("Acceptable Check", "Warning")])
-            XCTAssertEqual(checkResult.failures, [("Rejected Check", "Failure")])
-        }
+        let inputReport = dummyReport()
+        XCTAssertEqual(inputReport.failures, [("FAILURE 1", "Failure Message"), ("FAILURE 2", nil)])
         
     }
     
 }
 
-private func XCTAssertEqual(_ itemA: [Report.CheckItem], _ itemB: [Report.CheckItem], line: UInt = #line) {
+private func XCTAssertEqual(_ anyCollection: AnyCollection<Report.WarningMessage>, _ array: Array<Report.WarningMessage>, line: UInt = #line) {
     
-    XCTAssertEqual(itemA.count, itemB.count, line: line)
-    
-    for itemTuple in zip(itemA, itemB) {
-        XCTAssertEqual(itemTuple.0.title, itemTuple.1.title, line: line)
-        XCTAssertEqual(itemTuple.0.result, itemTuple.1.result, line: line)
+    guard anyCollection.count == array.count else {
+        return XCTFail(line: line)
     }
     
-}
-
-private func XCTAssertEqual(_ itemA: AnyCollection<Report.WarningMessage>, _ itemB: [Report.WarningMessage], line: UInt = #line) {
-    
-    XCTAssertEqual(itemA.count, itemB.count, line: line)
-    
-    for itemTuple in zip(itemA, itemB) {
-        XCTAssertEqual(itemTuple.0.title, itemTuple.1.title, line: line)
-        XCTAssertEqual(itemTuple.0.message, itemTuple.1.message, line: line)
+    for tuple in zip(anyCollection, array) {
+        XCTAssertEqual(tuple.0.title, tuple.1.title, line: line)
+        XCTAssertEqual(tuple.0.message, tuple.1.message, line: line)
     }
     
 }

--- a/Tests/DangerSwiftShokiTests/ReportTests.swift
+++ b/Tests/DangerSwiftShokiTests/ReportTests.swift
@@ -1,11 +1,11 @@
 import XCTest
 @testable import DangerSwiftShoki
 
-final class CheckResultTests: XCTestCase {
+final class ReportTests: XCTestCase {
     
-    func test_checkResultLife() {
+    func test_reportUsageScenario() {
         
-        var checkResult = CheckResult(title: "Test Check")
+        var checkResult = Report(title: "Test Check")
         
         XCTContext.runActivity(named: "Initialize CheckResult") { _ in
             XCTAssertEqual(checkResult.title, "Test Check")
@@ -72,7 +72,7 @@ final class CheckResultTests: XCTestCase {
     
 }
 
-private func XCTAssertEqual(_ itemA: [CheckResult.CheckItem], _ itemB: [CheckResult.CheckItem], line: UInt = #line) {
+private func XCTAssertEqual(_ itemA: [Report.CheckItem], _ itemB: [Report.CheckItem], line: UInt = #line) {
     
     XCTAssertEqual(itemA.count, itemB.count, line: line)
     
@@ -83,7 +83,7 @@ private func XCTAssertEqual(_ itemA: [CheckResult.CheckItem], _ itemB: [CheckRes
     
 }
 
-private func XCTAssertEqual(_ itemA: AnyCollection<CheckResult.WarningMessage>, _ itemB: [CheckResult.WarningMessage], line: UInt = #line) {
+private func XCTAssertEqual(_ itemA: AnyCollection<Report.WarningMessage>, _ itemB: [Report.WarningMessage], line: UInt = #line) {
     
     XCTAssertEqual(itemA.count, itemB.count, line: line)
     

--- a/Tests/DangerSwiftShokiTests/ShokiTests.swift
+++ b/Tests/DangerSwiftShokiTests/ShokiTests.swift
@@ -33,8 +33,8 @@ final class ShokiTests: XCTestCase {
         
         XCTContext.runActivity(named: "Good CheckResult") { _ in
             
-            let inputResult = { () -> CheckResult in
-                var result = CheckResult(title: "Good Result")
+            let inputReport = { () -> Report in
+                var result = Report(title: "Good Result")
                 result.checkItems.append(("Good Check", .good))
                 result.todos.append("Good Todo")
                 return result
@@ -69,14 +69,14 @@ final class ShokiTests: XCTestCase {
                 failureExecutor: { _ in XCTFail() }
             )
             
-            shoki.report(inputResult)
+            shoki.report(inputReport)
             wait(for: [titleExpectation, messageExpectation, todosExpectation, rewardExpectation], timeout: 0, enforceOrder: true)
             
         }
         
         XCTContext.runActivity(named: "Empty CheckResult") { _ in
             
-            let inputResult = CheckResult(title: "Empty Result")
+            let inputReport = Report(title: "Empty Result")
             
             let titleExpectation = expectation(description: "Title")
             let rewardExpectation = expectation(description: "Reward")
@@ -97,15 +97,15 @@ final class ShokiTests: XCTestCase {
                 failureExecutor: { _ in XCTFail() }
             )
             
-            shoki.report(inputResult)
+            shoki.report(inputReport)
             wait(for: [titleExpectation, rewardExpectation], timeout: 0, enforceOrder: true)
             
         }
         
         XCTContext.runActivity(named: "Rejected Result") { _ in
             
-            let inputResult = { () -> CheckResult in
-                var result = CheckResult(title: "Rejected Result")
+            let inputReport = { () -> Report in
+                var result = Report(title: "Rejected Result")
                 result.checkItems.append(("Rejected Check", .rejected(failureMessage: nil)))
                 return result
             }()
@@ -137,7 +137,7 @@ final class ShokiTests: XCTestCase {
                 failureExecutor: failureExecutor
             )
             
-            shoki.report(inputResult)
+            shoki.report(inputReport)
             wait(for: [titleExpectation, messageExpectation, failureExpectation], timeout: 0, enforceOrder: true)
             
         }


### PR DESCRIPTION
A big fix of responsibility refactor:

- Rename `CheckResult` to `Report`
- Make `Report` a pure data structure type
- Add a `MarkdownConfiguration` type for formatting customization
- Move formatting implementations to `Shoki`
- Tests and README updates due to modifications above
